### PR TITLE
add removeworker node script and upgrade and dsc and dsci

### DIFF
--- a/Hacks/remove_image_from_worker_node.sh
+++ b/Hacks/remove_image_from_worker_node.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Get only worker nodes (nodes without the master/control-plane role)
+WORKER_NODES=$(oc get nodes -l '!node-role.kubernetes.io/master' -o jsonpath='{.items[*].metadata.name}')
+
+# Check if we got any worker nodes
+if [ -z "$WORKER_NODES" ]; then
+    echo "Error: No worker nodes found in the cluster"
+    exit 1
+fi
+
+echo "Found worker nodes: $WORKER_NODES"
+echo "Starting Podman image cleanup on worker nodes..."
+echo ""
+
+# Function to clean images on a single node
+clean_worker_node() {
+    local NODE=$1
+    echo "Processing worker node: $NODE"
+
+    oc debug node/$NODE --quiet -- chroot /host /bin/bash -c "
+        echo 'Current Podman images on $NODE:';
+        podman images --format 'table {{.ID}}\t{{.Repository}}:{{.Tag}}' || echo 'No images found';
+        echo 'Removing all images...';
+        podman rmi -a -f 2>/dev/null || echo 'No images to remove';
+        echo 'Verifying cleanup:';
+        podman images || echo 'No images remaining';
+        echo 'Done on $NODE'
+    " 2>&1 | sed "s/^/[${NODE}] /"
+
+    echo "----------------------------------------"
+}
+
+# Process worker nodes in parallel (max 3 at a time for safety)
+export -f clean_worker_node
+echo "$WORKER_NODES" | tr ' ' '\n' | xargs -P3 -I{} bash -c 'clean_worker_node "$@"' _ {}
+
+echo "Podman image cleanup completed on all worker nodes"

--- a/Hacks/run_upgrade_matrix.sh
+++ b/Hacks/run_upgrade_matrix.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Configuration
+upgrade_from="2.19"
+upgrade_to="2.20"
+test_dir="opendatahub-tests"
+log_dir="/var/www/html"
+
+# Clone the repository
+git clone https://github.com/opendatahub-io/opendatahub-tests.git
+cd "$test_dir" || exit
+
+# Scenario 1: Serverless and ModelMesh
+echo "Running Scenario 1: Serverless and ModelMesh"
+
+# Pre-upgrade steps
+python main.py --cleanup
+python main.py --all --rhoai --rhoai-channel=fast --rhoai-image="quay.io/rhoai/rhoai-fbc-fragment:rhoai-${upgrade_from}-nightly" --raw=False --deploy-rhoai-resources
+
+# Pre-upgrade tests
+echo "Running pre-upgrade tests for Scenario 1"
+PYTHONUNBUFFERED=1 stdbuf -oL -eL uv run pytest -m "pre_upgrade and serverless and modelmesh" --tc=distribution:downstream 2>&1 | tee "${log_dir}/pre_upgrade_${upgrade_to}.log"
+
+# Post-upgrade steps
+cd .. || exit
+python main.py --all --rhoai --rhoai-channel=fast --rhoai-image="quay.io/rhoai/rhoai-fbc-fragment:rhoai-${upgrade_to}-nightly" --raw=False
+
+# Post-upgrade tests
+echo "Running post-upgrade tests for Scenario 1"
+cd "$test_dir" || exit
+PYTHONUNBUFFERED=1 stdbuf -oL -eL uv run pytest -m "post_upgrade and serverless and modelmesh" --tc=distribution:downstream 2>&1 | tee "${log_dir}/post_upgrade_${upgrade_to}.log"
+
+# Scenario 2: Raw Deployment
+echo "Running Scenario 2: Raw Deployment"
+
+# Pre-upgrade steps
+cd .. || exit
+python main.py --cleanup
+python main.py --rhoai --rhoai-channel=fast --rhoai-image="quay.io/rhoai/rhoai-fbc-fragment:rhoai-${upgrade_from}-nightly" --raw=True --deploy-rhoai-resources
+
+# Pre-upgrade tests
+echo "Running pre-upgrade tests for Scenario 2"
+cd "$test_dir" || exit
+PYTHONUNBUFFERED=1 stdbuf -oL -eL uv run pytest -m "pre_upgrade and rawdeployment" --tc=distribution:downstream 2>&1 | tee "${log_dir}/pre_upgrade_${upgrade_to}_1.log"
+
+# Post-upgrade steps
+cd .. || exit
+python main.py --all --rhoai --rhoai-channel=fast --rhoai-image="quay.io/rhoai/rhoai-fbc-fragment:rhoai-${upgrade_to}-nightly" --raw=True
+
+# Post-upgrade tests
+echo "Running post-upgrade tests for Scenario 2"
+cd "$test_dir" || exit
+PYTHONUNBUFFERED=1 stdbuf -oL -eL uv run pytest -m "post_upgrade and rawdeployment" --tc=distribution:downstream 2>&1 | tee "${log_dir}/post_upgrade_${upgrade_to}_1.log"
+
+echo "All upgrade tests completed"

--- a/Readme.md
+++ b/Readme.md
@@ -77,6 +77,9 @@ python main.py --rhoai --rhoai-channel=<channel> --rhoai-image=<image> --raw=Fal
 # Install all operators 
 python main.py --all
 
+# create dsc and dsci with rhoai operator installarion
+python main.py --rhoai --rhoai-channel=<channel> --rhoai-image=<image> --raw=False --deploy-rhoai-resources
+
 # Verbose output
 python main.py --all --verbose
 ```

--- a/cli/args.py
+++ b/cli/args.py
@@ -21,6 +21,8 @@ def parse_args() -> argparse.Namespace:
                            help="Install all operators")
     operators.add_argument("--cleanup", action="store_true",
                            help="clean up all RHOAI, serverless , servishmesh , Authorino Operator ")
+    operators.add_argument("--deploy-rhoai-resources", action="store_true",
+                           help="creates dsc and dsci")
 
     # Configuration options
     config = parser.add_argument_group("Configuration")

--- a/cli/args.py
+++ b/cli/args.py
@@ -21,8 +21,8 @@ def parse_args() -> argparse.Namespace:
                            help="Install all operators")
     operators.add_argument("--cleanup", action="store_true",
                            help="clean up all RHOAI, serverless , servishmesh , Authorino Operator ")
-    operators.add_argument("--deploy-rhoai-resources", action="store_true",
-                           help="creates dsc and dsci")
+    operators.add_argument("--deploy-rhoai-resources", required='--rhoai' in sys.argv,
+                           action="store_true", help="creates dsc and dsci")
 
     # Configuration options
     config = parser.add_argument_group("Configuration")

--- a/cli/commands.py
+++ b/cli/commands.py
@@ -1,8 +1,6 @@
 # commands.py
 import sys
 
-from sqlalchemy import false
-
 sys.dont_write_bytecode = True
 
 import logging
@@ -40,6 +38,7 @@ def install_operator(op_name: str, config: Dict[str, Any]) -> bool:
             'channel': config.get("rhoai_channel"),
             'rhoai_image': config.get("rhoai_image"),
             'raw': config.get("raw", False),
+            'create_dsc_dsci': config.get("create_dsc_dsci", False),
             'csv_name': 'rhods-operator',
             'namespace': 'redhat-ods-operators',
             'display': 'display:RHOAI Operator'

--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from logger.logger import Logger
 logger = Logger.get_logger(__name__)
 
 
-def main() -> int:
+def main() -> int | None:
     """Main entry point for the operator installation tool."""
 
     def display_large_banner():
@@ -43,6 +43,7 @@ def main() -> int:
             'rhoai_image': args.rhoai_image,
             'rhoai_channel': args.rhoai_channel,
             'raw': args.raw,
+            'create_dsc_dsci': args.deploy_rhoai_resources,
         }
         logger.info(config)
         # Determine which operators to install
@@ -76,6 +77,7 @@ def main() -> int:
         if not args.cleanup:
             logger.error("Operator installation failed")
             return 1
+        return None
 
     except Exception as e:
         logger.error(f"An error occurred: {str(e)}", exc_info=True)

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -278,4 +278,4 @@ def wait_for_resource_for_specific_status(
         f"Timeout after {elapsed:.1f}s waiting for status '{status}'. "
         f"Last output: {last_stdout.strip()}"
     )
-    return (False, last_stdout, last_stderr)
+    return False, last_stdout, last_stderr


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new command-line flag to optionally create DSC and DSCI resources during RHOAI operator installation.
  - Introduced a script to automate upgrade testing between different OpenDataHub versions.
  - Added a script for cleaning up Podman container images on Kubernetes worker nodes.

- **Bug Fixes**
  - Corrected a parameter name in the resource deletion method for improved reliability.

- **Chores**
  - Removed unused imports and made minor code style improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->