### PR TITLE
fix(upgrade): address upgrade flow gaps and add --upgrade CLI command

### DIFF
--- a/rhoshift/cli/args.py
+++ b/rhoshift/cli/args.py
@@ -68,6 +68,66 @@ def parse_args() -> argparse.Namespace:
         help="Show detailed summary of all supported operators and their versions",
     )
 
+    # Upgrade workflow
+    upgrade_group = parser.add_argument_group("Upgrade Workflow")
+    upgrade_group.add_argument(
+        "--upgrade",
+        action="store_true",
+        help="Run full upgrade workflow: install base → pre-tests → upgrade → post-tests",
+    )
+    upgrade_group.add_argument(
+        "--from-image",
+        type=str,
+        default=None,
+        help="Base (source) FBC fragment image for upgrade",
+    )
+    upgrade_group.add_argument(
+        "--to-image",
+        type=str,
+        default=None,
+        help="Target FBC fragment image to upgrade to",
+    )
+    upgrade_group.add_argument(
+        "--test-path",
+        type=str,
+        default=None,
+        help="Pytest path filter, e.g. tests/model_serving/model_server",
+    )
+    upgrade_group.add_argument(
+        "--test-markers",
+        type=str,
+        default=None,
+        help="Extra pytest markers to add (comma-separated)",
+    )
+    upgrade_group.add_argument(
+        "--skip-tests",
+        action="store_true",
+        help="Skip pre/post upgrade tests (upgrade only)",
+    )
+    upgrade_group.add_argument(
+        "--skip-cleanup",
+        action="store_true",
+        help="Skip cleanup before base version install",
+    )
+    upgrade_group.add_argument(
+        "--wait-time",
+        type=int,
+        default=600,
+        help="Seconds to wait for pods to stabilize after upgrade (default: 600)",
+    )
+    upgrade_group.add_argument(
+        "--from-channel",
+        type=str,
+        default=None,
+        help="Channel for base version (default: uses --rhoai-channel)",
+    )
+    upgrade_group.add_argument(
+        "--to-channel",
+        type=str,
+        default=None,
+        help="Channel for target version (default: uses --rhoai-channel)",
+    )
+
     # Configuration options
     config = parser.add_argument_group("Configuration")
     config.add_argument(

--- a/rhoshift/cli/commands.py
+++ b/rhoshift/cli/commands.py
@@ -3,12 +3,17 @@ import sys
 
 sys.dont_write_bytecode = True
 
+import json
 import logging
-from typing import Any, Dict
+import os
+import tempfile
+import time
+from typing import Any, Dict, Optional
 
 from rhoshift.utils.operator.enhanced_operator import EnhancedOpenShiftOperatorInstaller
 from rhoshift.utils.operator.operator import OpenShiftOperatorInstaller
 from rhoshift.utils.stability_coordinator import StabilityLevel
+from rhoshift.utils.utils import run_command
 
 logger = logging.getLogger(__name__)
 
@@ -269,3 +274,297 @@ def install_operators(selected_ops: Dict[str, bool], config: Dict[str, Any]) -> 
                 logger.info(f"✅ Successfully installed {op_name}")
 
     return success
+
+
+def _wait_for_pods_stable(
+    namespace: str = "redhat-ods-applications",
+    wait_time: int = 600,
+    oc_binary: str = "oc",
+) -> bool:
+    """Wait for pods to stabilize after upgrade, checking readiness periodically."""
+    logger.info(f"⏳ Waiting up to {wait_time}s for pods to stabilize in {namespace}...")
+    interval = 30
+    elapsed = 0
+
+    while elapsed < wait_time:
+        cmd = (
+            f"{oc_binary} get pods -n {namespace} --no-headers "
+            f"-o custom-columns=NAME:.metadata.name,READY:.status.containerStatuses[*].ready,STATUS:.status.phase "
+            f"2>/dev/null"
+        )
+        rc, stdout, _ = run_command(cmd, log_output=False)
+        if rc == 0:
+            lines = [l for l in stdout.strip().splitlines() if l.strip()]
+            not_ready = [l for l in lines if "true" not in l.lower() or "Running" not in l]
+            if not not_ready:
+                logger.info(f"✅ All pods ready in {namespace} after {elapsed}s")
+                return True
+            logger.info(
+                f"⏱️  {len(not_ready)} pod(s) not ready yet ({elapsed}/{wait_time}s)..."
+            )
+        time.sleep(interval)
+        elapsed += interval
+
+    logger.warning(f"⚠️  Pod stabilization timed out after {wait_time}s")
+    return False
+
+
+def _run_upgrade_tests(
+    phase: str,
+    test_dir: str,
+    test_path: Optional[str] = None,
+    test_markers: Optional[str] = None,
+    deployment_mode: str = "rawdeployment",
+) -> Dict[str, Any]:
+    """Run pre or post upgrade tests and return structured results."""
+    marker_flag = f"--{phase}-upgrade"
+    cmd_parts = [
+        "uv", "run", "pytest",
+        marker_flag,
+        f"--upgrade-deployment-modes={deployment_mode}",
+        "--tc=distribution:downstream",
+        "-v",
+    ]
+    if test_markers:
+        cmd_parts.extend(["-m", test_markers])
+    if test_path:
+        cmd_parts.append(test_path)
+
+    cmd = " ".join(cmd_parts)
+    logger.info(f"🧪 Running {phase}-upgrade tests: {cmd}")
+
+    rc, stdout, stderr = run_command(cmd, timeout=3600, cwd=test_dir, log_output=True)
+
+    passed = rc == 0
+    summary = ""
+    for line in stdout.splitlines():
+        if "passed" in line or "failed" in line or "error" in line:
+            summary = line.strip()
+
+    return {
+        "phase": phase,
+        "passed": passed,
+        "return_code": rc,
+        "summary": summary or ("All tests passed" if passed else f"Tests failed (rc={rc})"),
+    }
+
+
+def _clone_test_repo(
+    repo_url: str = "https://github.com/opendatahub-io/opendatahub-tests.git",
+    target_dir: Optional[str] = None,
+) -> str:
+    """Clone or update the test repository. Returns the path."""
+    if target_dir is None:
+        target_dir = os.path.join(
+            tempfile.gettempdir(), "rhoshift-upgrade-tests", "opendatahub-tests"
+        )
+
+    if os.path.isdir(os.path.join(target_dir, ".git")):
+        logger.info(f"📂 Updating existing test repo at {target_dir}")
+        run_command(f"git -C {target_dir} pull --quiet", log_output=False)
+    else:
+        logger.info(f"📥 Cloning test repo to {target_dir}")
+        os.makedirs(os.path.dirname(target_dir), exist_ok=True)
+        rc, _, stderr = run_command(
+            f"git clone --quiet {repo_url} {target_dir}",
+            timeout=300,
+            log_output=True,
+        )
+        if rc != 0:
+            raise RuntimeError(f"Failed to clone test repo: {stderr}")
+
+    return target_dir
+
+
+def run_upgrade(config: Dict[str, Any]) -> int:
+    """Orchestrate a full RHOAI upgrade workflow.
+
+    Steps:
+      1. Cleanup (optional)
+      2. Install base version with --deploy-rhoai-resources
+      3. Clone test repo & run pre-upgrade tests
+      4. Upgrade to target version (preserves DSC/DSCI)
+      5. Wait for pods to stabilize
+      6. Run post-upgrade tests
+      7. Generate and print upgrade report
+
+    Returns 0 on success, 1 on failure.
+    """
+    from_image = config["from_image"]
+    to_image = config["to_image"]
+    from_channel = config.get("from_channel") or config.get("rhoai_channel", "fast")
+    to_channel = config.get("to_channel") or config.get("rhoai_channel", "fast")
+    oc_binary = config.get("oc_binary", "oc")
+    wait_time = config.get("wait_time", 600)
+    skip_tests = config.get("skip_tests", False)
+    skip_cleanup = config.get("skip_cleanup", False)
+    test_path = config.get("test_path")
+    test_markers = config.get("test_markers")
+
+    report = {
+        "from_image": from_image,
+        "to_image": to_image,
+        "from_channel": from_channel,
+        "to_channel": to_channel,
+        "phases": {},
+    }
+
+    start_time = time.time()
+
+    # --- Phase 0: Cleanup ---
+    if not skip_cleanup:
+        logger.info("🧹 [Phase 0/6] Cleaning up existing installation...")
+        try:
+            from rhoshift.utils.operator.cleanup import cleanup
+
+            cleanup()
+            report["phases"]["cleanup"] = {"status": "success"}
+        except Exception as e:
+            logger.error(f"❌ Cleanup failed: {e}")
+            report["phases"]["cleanup"] = {"status": "failed", "error": str(e)}
+            return 1
+    else:
+        logger.info("⏭️  Skipping cleanup (--skip-cleanup)")
+
+    # --- Phase 1: Install base version ---
+    logger.info(f"📦 [Phase 1/6] Installing base version: {from_image}")
+    base_config = {
+        **config,
+        "rhoai_image": from_image,
+        "rhoai_channel": from_channel,
+        "create_dsc_dsci": True,
+    }
+    base_success = install_operator("rhoai", base_config)
+    report["phases"]["base_install"] = {
+        "status": "success" if base_success else "failed",
+        "image": from_image,
+        "channel": from_channel,
+    }
+    if not base_success:
+        logger.error("❌ Base version installation failed. Aborting upgrade.")
+        return 1
+    logger.info("✅ Base version installed successfully")
+
+    # --- Phase 2: Pre-upgrade tests ---
+    pre_results = {"phase": "pre", "passed": True, "summary": "skipped"}
+    test_dir = None
+    if not skip_tests:
+        logger.info("🧪 [Phase 2/6] Running pre-upgrade tests...")
+        try:
+            test_dir = _clone_test_repo()
+            pre_results = _run_upgrade_tests(
+                phase="pre",
+                test_dir=test_dir,
+                test_path=test_path,
+                test_markers=test_markers,
+            )
+        except Exception as e:
+            logger.error(f"❌ Pre-upgrade test setup failed: {e}")
+            pre_results = {"phase": "pre", "passed": False, "summary": str(e)}
+    else:
+        logger.info("⏭️  Skipping pre-upgrade tests (--skip-tests)")
+
+    report["phases"]["pre_upgrade_tests"] = pre_results
+    if not pre_results["passed"]:
+        logger.warning(f"⚠️  Pre-upgrade tests failed: {pre_results['summary']}")
+        logger.warning("Continuing with upgrade despite pre-test failures...")
+
+    # --- Phase 3: Upgrade ---
+    logger.info(f"⬆️  [Phase 3/6] Upgrading to: {to_image}")
+    upgrade_config = {
+        **config,
+        "rhoai_image": to_image,
+        "rhoai_channel": to_channel,
+        "create_dsc_dsci": False,
+    }
+    upgrade_success = install_operator("rhoai", upgrade_config)
+    report["phases"]["upgrade"] = {
+        "status": "success" if upgrade_success else "failed",
+        "image": to_image,
+        "channel": to_channel,
+    }
+    if not upgrade_success:
+        logger.error("❌ Upgrade failed.")
+        return 1
+    logger.info("✅ Upgrade applied successfully")
+
+    # --- Phase 4: Wait for stabilization ---
+    logger.info(f"⏳ [Phase 4/6] Waiting {wait_time}s for pods to stabilize...")
+    ns = "opendatahub" if to_channel == "odh-nightlies" else "redhat-ods-applications"
+    pods_stable = _wait_for_pods_stable(
+        namespace=ns, wait_time=wait_time, oc_binary=oc_binary
+    )
+    report["phases"]["stabilization"] = {
+        "status": "success" if pods_stable else "warning",
+        "wait_time": wait_time,
+    }
+
+    # --- Phase 5: Post-upgrade tests ---
+    post_results = {"phase": "post", "passed": True, "summary": "skipped"}
+    if not skip_tests:
+        logger.info("🧪 [Phase 5/6] Running post-upgrade tests...")
+        if test_dir is None:
+            test_dir = _clone_test_repo()
+        post_results = _run_upgrade_tests(
+            phase="post",
+            test_dir=test_dir,
+            test_path=test_path,
+            test_markers=test_markers,
+        )
+    else:
+        logger.info("⏭️  Skipping post-upgrade tests (--skip-tests)")
+
+    report["phases"]["post_upgrade_tests"] = post_results
+
+    # --- Phase 6: Report ---
+    elapsed = time.time() - start_time
+    report["elapsed_seconds"] = round(elapsed, 1)
+
+    try:
+        upgrade_report = OpenShiftOperatorInstaller.generate_upgrade_report(
+            from_channel=from_channel,
+            to_channel=to_channel,
+            from_image=from_image,
+            to_image=to_image,
+            oc_binary=oc_binary,
+        )
+        report["cluster_state"] = upgrade_report
+    except Exception as e:
+        logger.warning(f"⚠️  Failed to generate cluster state report: {e}")
+
+    logger.info("=" * 70)
+    logger.info("📊 UPGRADE REPORT")
+    logger.info("=" * 70)
+    logger.info(f"  From: {from_image}")
+    logger.info(f"  To:   {to_image}")
+    logger.info(f"  Time: {elapsed:.0f}s")
+    logger.info(
+        f"  Base install:    {report['phases'].get('base_install', {}).get('status', 'n/a')}"
+    )
+    logger.info(f"  Pre-upgrade:     {pre_results.get('summary', 'n/a')}")
+    logger.info(
+        f"  Upgrade:         {report['phases'].get('upgrade', {}).get('status', 'n/a')}"
+    )
+    logger.info(
+        f"  Stabilization:   {report['phases'].get('stabilization', {}).get('status', 'n/a')}"
+    )
+    logger.info(f"  Post-upgrade:    {post_results.get('summary', 'n/a')}")
+    logger.info("=" * 70)
+
+    report_path = os.path.join(tempfile.gettempdir(), "rhoshift-upgrade-report.json")
+    with open(report_path, "w") as f:
+        json.dump(report, f, indent=2, default=str)
+    logger.info(f"📄 Full report saved to: {report_path}")
+
+    all_passed = (
+        report["phases"].get("upgrade", {}).get("status") == "success"
+        and pre_results.get("passed", True)
+        and post_results.get("passed", True)
+    )
+
+    if all_passed:
+        logger.info("🎉 Upgrade completed successfully!")
+        return 0
+    else:
+        logger.error("❌ Upgrade completed with failures. See report above.")
+        return 1

--- a/rhoshift/main.py
+++ b/rhoshift/main.py
@@ -149,7 +149,26 @@ def main() -> Optional[int]:
                             generate_health_report,
                         )
 
-                        logger.info("✅ Post-installation health checks completed")
+                        ns = (
+                            "opendatahub-operators"
+                            if config.get("rhoai_channel") == "odh-nightlies"
+                            else "redhat-ods-operator"
+                        )
+                        op_name = (
+                            "opendatahub-operator"
+                            if config.get("rhoai_channel") == "odh-nightlies"
+                            else "rhods-operator"
+                        )
+                        health_status, health_results = check_operator_health(
+                            operator_name=op_name,
+                            namespace=ns,
+                            oc_binary=config.get("oc_binary", "oc"),
+                        )
+                        report = generate_health_report(health_results)
+                        logger.info(f"Health report:\n{report}")
+                        logger.info(
+                            f"✅ Post-installation health checks completed: {health_status.value}"
+                        )
                     except Exception as health_error:
                         logger.warning(
                             f"⚠️  Post-installation health check failed: {health_error}"

--- a/rhoshift/main.py
+++ b/rhoshift/main.py
@@ -47,6 +47,38 @@ def main() -> Optional[int]:
         if args.cleanup:
             cleanup()
 
+        # Handle --upgrade workflow
+        if args.upgrade:
+            if not args.from_image or not args.to_image:
+                logger.error(
+                    "❌ --upgrade requires both --from-image and --to-image"
+                )
+                return 1
+
+            from rhoshift.cli.commands import run_upgrade
+
+            upgrade_config = {
+                "oc_binary": args.oc_binary,
+                "max_retries": args.retries,
+                "retry_delay": args.retry_delay,
+                "timeout": args.timeout,
+                "rhoai_channel": args.rhoai_channel,
+                "raw": args.raw,
+                "from_image": args.from_image,
+                "to_image": args.to_image,
+                "from_channel": args.from_channel or args.rhoai_channel,
+                "to_channel": args.to_channel or args.rhoai_channel,
+                "test_path": args.test_path,
+                "test_markers": args.test_markers,
+                "skip_tests": args.skip_tests,
+                "skip_cleanup": args.skip_cleanup,
+                "wait_time": args.wait_time,
+                "stability_level": StabilityLevel.ENHANCED,
+                "enable_health_monitoring": True,
+                "enable_auto_recovery": True,
+            }
+            return run_upgrade(upgrade_config)
+
         # Pre-flight validation for cluster readiness
         if not args.cleanup and any(
             [

--- a/rhoshift/utils/constants.py
+++ b/rhoshift/utils/constants.py
@@ -534,12 +534,6 @@ spec:
   monitoring:
     managementState: Managed
     namespace: {monitoring_namespace}
-  serviceMesh:
-    controlPlane:
-      metricsCollection: Istio
-      name: data-science-smcp
-      namespace: istio-system
-    managementState: {to_state(kserve_raw)}
   trustedCABundle:
     customCABundle: ''
     managementState: Managed
@@ -560,11 +554,13 @@ def get_dsc_manifest(
     enable_modelmeshserving=True,
     operator_namespace="rhods-operator",
     kueue_management_state=None,
+    nim_management_state="Removed",
 ):
     def to_state(flag):
         return "Managed" if flag else "Removed"
 
-    # Build the base manifest
+    serving_state = to_state(not enable_raw_serving)
+
     manifest = f"""apiVersion: datasciencecluster.opendatahub.io/v1
 kind: DataScienceCluster
 metadata:
@@ -582,21 +578,19 @@ spec:
     kserve:
       managementState: {to_state(enable_kserve)}
       nim:
-        managementState: Managed
+        managementState: {nim_management_state}
       serving:
         ingressGateway:
           certificate:
             type: OpenshiftDefaultIngress
-        managementState: {to_state(enable_raw_serving ^ True)}
+        managementState: {serving_state}
         name: knative-serving"""
 
-    # Add Kueue component if kueue_management_state is specified
     if kueue_management_state is not None:
         manifest += f"""
     kueue:
       managementState: {kueue_management_state}"""
 
-    # Add modelmeshserving component
     manifest += f"""
     modelmeshserving:
       managementState: {to_state(enable_modelmeshserving)}

--- a/rhoshift/utils/operator/enhanced_operator.py
+++ b/rhoshift/utils/operator/enhanced_operator.py
@@ -359,8 +359,11 @@ spec:
                 )
             else:
                 warnings.append(
-                    f"⚠️  DSCI compatibility: existing monitoring namespace is '{existing_monitoring_ns}', channel '{channel}' prefers '{desired_monitoring_ns}'. Using existing configuration."
+                    f"❌ DSCI incompatible: existing monitoring namespace is '{existing_monitoring_ns}', "
+                    f"channel '{channel}' requires '{desired_monitoring_ns}'. "
+                    f"Use --deploy-rhoai-resources to force recreate, or manually update the DSCI."
                 )
+                return False, warnings
         else:
             warnings.append(
                 f"✅ DSCI compatible: monitoring namespace '{existing_monitoring_ns}' matches channel '{channel}'"

--- a/rhoshift/utils/operator/operator.py
+++ b/rhoshift/utils/operator/operator.py
@@ -575,12 +575,17 @@ spec:
                 if channel == "odh-nightlies"
                 else "redhat-ods-operator"
             )
-            operator_name = (
-                "opendatahub-operator.1.18.0"
+            operator_prefix = (
+                "opendatahub-operator"
                 if channel == "odh-nightlies"
                 else "rhods-operator"
             )
-            # namespace = "redhat-ods-operator"
+
+            operator_name = cls._resolve_csv_name(
+                prefix=operator_prefix,
+                namespace=namespace,
+                oc_binary=oc_binary,
+            )
             results = cls.wait_for_operator(
                 operator_name=operator_name,
                 namespace=namespace,
@@ -625,6 +630,29 @@ spec:
                     run_command(f"rm -rf {temp_dir}", log_output=False)
             except Exception:
                 pass
+
+    @classmethod
+    def _resolve_csv_name(
+        cls,
+        prefix: str,
+        namespace: str,
+        oc_binary: str = "oc",
+    ) -> str:
+        """Resolve the actual CSV name from the cluster by prefix.
+
+        Avoids hardcoding version-specific CSV names like
+        ``opendatahub-operator.1.18.0`` which break on version bumps.
+        Falls back to the bare prefix if no CSV is found yet.
+        """
+        cmd = (
+            f"{oc_binary} get csv -n {namespace} --no-headers "
+            f"-o custom-columns=NAME:.metadata.name 2>/dev/null "
+            f"| grep '^{prefix}' | tail -1"
+        )
+        rc, stdout, _ = run_command(cmd, log_output=False)
+        resolved = stdout.strip() if rc == 0 and stdout.strip() else prefix
+        logger.info(f"Resolved CSV name: {resolved} (prefix={prefix})")
+        return resolved
 
     @classmethod
     def _install_operator(
@@ -1095,8 +1123,7 @@ spec:
         """
         logging.debug("Deploying Data Science Cluster and Instance resources...")
         if create_dsc_dsci:
-            # Delete old dsc and dsci
-            result = cls.force_delete_rhoai_dsc_dsci()
+            result = cls.force_delete_rhoai_dsc_dsci(channel=channel)
             # Check results
             dsci_deletion_successful = False
             for cmd_name, cmd_result in result.items():
@@ -1391,3 +1418,62 @@ spec:
             logger.info(f"{status_icon} {name}: {result['message']}")
 
         return results
+
+    @classmethod
+    def generate_upgrade_report(
+        cls,
+        from_channel: str,
+        to_channel: str,
+        from_image: str,
+        to_image: str,
+        namespace: str = "redhat-ods-operator",
+        oc_binary: str = "oc",
+    ) -> dict:
+        """Generate a structured JSON upgrade report capturing cluster state.
+
+        Returns a dict suitable for JSON serialisation with CSV versions,
+        DSC conditions, component readiness, and kserve/dashboard status.
+        """
+        report: dict = {
+            "upgrade": {
+                "from_channel": from_channel,
+                "to_channel": to_channel,
+                "from_image": from_image,
+                "to_image": to_image,
+                "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            },
+            "csv": {},
+            "dsc": {},
+            "components": {},
+        }
+
+        csv_cmd = f"{oc_binary} get csv -n {namespace} --no-headers -o custom-columns=NAME:.metadata.name,PHASE:.status.phase 2>/dev/null"
+        rc, stdout, _ = run_command(csv_cmd, log_output=False)
+        if rc == 0:
+            for line in stdout.strip().splitlines():
+                parts = line.split()
+                if len(parts) >= 2:
+                    report["csv"][parts[0]] = parts[1]
+
+        dsc_cmd = (
+            f"{oc_binary} get dsc default-dsc -o json 2>/dev/null"
+        )
+        rc, stdout, _ = run_command(dsc_cmd, log_output=False)
+        if rc == 0:
+            try:
+                dsc_obj = json.loads(stdout)
+                conditions = dsc_obj.get("status", {}).get("conditions", [])
+                for cond in conditions:
+                    report["components"][cond.get("type", "")] = {
+                        "status": cond.get("status", ""),
+                        "reason": cond.get("reason", ""),
+                    }
+                report["dsc"]["ready"] = any(
+                    c.get("type") == "Ready" and c.get("status") == "True"
+                    for c in conditions
+                )
+            except json.JSONDecodeError:
+                report["dsc"]["error"] = "Failed to parse DSC JSON"
+
+        logger.info(f"Upgrade report:\n{json.dumps(report, indent=2)}")
+        return report

--- a/scripts/run_upgrade_matrix.sh
+++ b/scripts/run_upgrade_matrix.sh
@@ -370,6 +370,10 @@ check_pod_status() {
     fi
 }
 
+# Save original file descriptors for restoration inside the loop
+exec 3>&1
+exec 4>&2
+
 # Process each scenario
 for scenario in "${SCENARIOS_TO_RUN[@]}"; do
     log "INFO" "==================== [SCENARIO: ${scenario^^}] ===================="

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -180,40 +180,46 @@ class TestOpenShiftOperatorInstaller:
             assert result[0] == 0
             mock_install.assert_called_once_with("leader-worker-set")
 
-    @patch("rhoshift.utils.utils.apply_manifest")
-    @patch("rhoshift.utils.utils.wait_for_resource_for_specific_status")
+    @patch("rhoshift.utils.operator.operator.run_command")
+    @patch(
+        "rhoshift.utils.operator.operator.OpenShiftOperatorInstaller.wait_for_operator"
+    )
     @patch(
         "rhoshift.utils.operator.operator.OpenShiftOperatorInstaller.deploy_dsc_dsci"
     )
+    @patch(
+        "rhoshift.utils.operator.operator.OpenShiftOperatorInstaller._resolve_csv_name"
+    )
     def test_install_rhoai_operator_success(
-        self, mock_deploy_dsc_dsci, mock_wait, mock_apply
+        self, mock_resolve, mock_deploy_dsc_dsci, mock_wait, mock_run_cmd
     ):
-        """Test successful RHOAI operator installation"""
-        mock_apply.return_value = (0, "applied", "")
-        mock_wait.return_value = (True, "Succeeded", "")
+        """Test successful RHOAI operator installation returns a dict"""
+        mock_run_cmd.return_value = (0, "done", "")
+        mock_resolve.return_value = "rhods-operator"
+        mock_wait.return_value = {"rhods-operator": {"status": "installed"}}
         mock_deploy_dsc_dsci.return_value = None
 
-        rc, stdout, stderr = OpenShiftOperatorInstaller.install_rhoai_operator(
+        result = OpenShiftOperatorInstaller.install_rhoai_operator(
             rhoai_image="test-image:latest",
             rhoai_channel="stable",
             create_dsc_dsci=True,
         )
 
-        assert rc == 0
-        assert "successfully" in stdout.lower()
+        assert isinstance(result, dict)
+        assert result.get("rhods-operator", {}).get("status") == "installed"
         mock_deploy_dsc_dsci.assert_called_once()
 
-    @patch("rhoshift.utils.utils.apply_manifest")
-    def test_install_rhoai_operator_manifest_failure(self, mock_apply):
-        """Test RHOAI operator installation with manifest failure"""
-        mock_apply.side_effect = Exception("Manifest failed")
+    @patch("rhoshift.utils.operator.operator.run_command")
+    def test_install_rhoai_operator_clone_failure(self, mock_run_cmd):
+        """Test RHOAI operator installation with clone failure"""
+        mock_run_cmd.return_value = (1, "", "clone failed")
 
-        rc, stdout, stderr = OpenShiftOperatorInstaller.install_rhoai_operator(
+        result = OpenShiftOperatorInstaller.install_rhoai_operator(
             rhoai_image="test-image:latest", rhoai_channel="stable"
         )
 
-        assert rc == 1
-        assert "failed" in stderr.lower()
+        assert isinstance(result, dict)
+        assert result.get("rhods-operator", {}).get("status") == "failed"
 
     @patch("rhoshift.utils.utils.run_command")
     def test_force_delete_rhoai_dsc_dsci(self, mock_run_command):
@@ -448,35 +454,20 @@ class TestOperatorManifestGeneration:
 class TestRHOAISpecificFeatures:
     """Test cases for RHOAI-specific features"""
 
-    @patch("rhoshift.utils.utils.run_command")
-    def test_kueue_dsc_integration_existing_dsc(self, mock_run_command):
-        """Test Kueue DSC integration with existing DSC"""
-        # Mock existing DSC
-        mock_run_command.side_effect = [
-            (0, "default-dsc", ""),  # DSC exists
-            (0, "patched", ""),  # Patch successful
-        ]
+    def test_dsc_manifest_includes_kueue_when_specified(self):
+        """Test DSC manifest includes Kueue when kueue_management_state is set"""
+        from rhoshift.utils.constants import get_dsc_manifest
 
-        from rhoshift.utils.operator.operator import update_kueue_in_dsc
+        manifest = get_dsc_manifest(kueue_management_state="Managed")
+        assert "kueue:" in manifest
+        assert "managementState: Managed" in manifest
 
-        result = update_kueue_in_dsc("Managed")
+    def test_dsc_manifest_excludes_kueue_when_none(self):
+        """Test DSC manifest excludes Kueue when kueue_management_state is None"""
+        from rhoshift.utils.constants import get_dsc_manifest
 
-        assert result[0] == 0
-        assert mock_run_command.call_count == 2
-
-    @patch("rhoshift.utils.utils.run_command")
-    def test_kueue_dsc_integration_no_existing_dsc(self, mock_run_command):
-        """Test Kueue DSC integration without existing DSC"""
-        # Mock no existing DSC
-        mock_run_command.return_value = (1, "", "not found")
-
-        from rhoshift.utils.operator.operator import update_kueue_in_dsc
-
-        result = update_kueue_in_dsc("Managed")
-
-        # Should indicate no DSC found
-        assert result[0] == 1
-        assert "not found" in result[2] or "No existing DSC" in result[1]
+        manifest = get_dsc_manifest(kueue_management_state=None)
+        assert "kueue:" not in manifest
 
 
 class TestErrorHandlingAndEdgeCases:


### PR DESCRIPTION
## Summary

- **Fix 9 upgrade flow gaps** across the rhoshift codebase:
  1. DSC manifest: fix XOR bug in serving `managementState`, default NIM to `Removed`, add `nim_management_state` param
  2. DSCI manifest: remove stale `serviceMesh`/Istio fields (no longer used in RHOAI 3.x)
  3. Hardcoded CSV name: replace `opendatahub-operator.1.18.0` with dynamic resolution via `_resolve_csv_name()`
  4. Health checks: actually invoke `check_operator_health()` and `generate_health_report()` post-install
  5. DSCI validation: return `False` when monitoring namespace is incompatible (was always returning `True`)
  6. Shell fd bug: save stdout/stderr to fds 3/4 before the scenario loop so restore works correctly
  7. Tests: fix `install_rhoai_operator` tests to expect `dict` return, replace broken `update_kueue_in_dsc` tests
  8. Namespace bug: pass `channel` to `force_delete_rhoai_dsc_dsci()` for correct odh-nightlies cleanup
  9. Upgrade report: add `generate_upgrade_report()` for structured JSON output

- **Add `--upgrade` CLI command** for end-to-end upgrade workflow in a single invocation:
  ```
  rhoshift --upgrade \
    --from-image <base-image> \
    --to-image <target-image> \
    --test-path tests/model_serving/model_server \
    --raw True
  ```
  Orchestrates: cleanup → base install → pre-upgrade tests → upgrade → pod stabilization → post-upgrade tests → JSON report

## New CLI Flags
| Flag | Default | Description |
|------|---------|-------------|
| `--upgrade` | - | Enable upgrade workflow |
| `--from-image` | required | Base FBC fragment image |
| `--to-image` | required | Target FBC fragment image |
| `--test-path` | all tests | Pytest path filter |
| `--test-markers` | none | Extra pytest markers |
| `--skip-tests` | false | Skip pre/post tests |
| `--skip-cleanup` | false | Skip cleanup before install |
| `--wait-time` | 600s | Pod stabilization wait |
| `--from-channel` | `--rhoai-channel` | Base version channel |
| `--to-channel` | `--rhoai-channel` | Target version channel |

## Test plan
- [ ] Verify `rhoshift --upgrade --from-image <3.3> --to-image <3.4> --raw True` runs full flow
- [ ] Verify `--skip-tests` skips pre/post tests correctly
- [ ] Verify `--skip-cleanup` preserves existing cluster state
- [ ] Verify upgrade report JSON is generated at `/tmp/rhoshift-upgrade-report.json`
- [ ] Verify existing `rhoshift --rhoai` install path is unaffected
- [ ] Verify `run_upgrade_matrix.sh` fd restore works across multiple scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced dedicated upgrade workflow with `--upgrade` flag and comprehensive configuration options for source/target specifications, test paths, and stability controls.
  * Added post-upgrade health monitoring and pod stabilization checks with configurable wait duration.
  * Implemented structured upgrade reporting with detailed status and diagnostic information.

* **Bug Fixes**
  * Enhanced operator installation to dynamically resolve operator versions at runtime instead of version-pinned selection.
  * Strengthened DSCI validation to detect namespace incompatibilities during upgrades.

* **Tests**
  * Refactored operator installation tests with improved mock coverage and updated validation expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->